### PR TITLE
make lib LINK_ARGS=... lost -lglfw

### DIFF
--- a/build-libraries.sh
+++ b/build-libraries.sh
@@ -26,7 +26,8 @@ mkdir -p $LIBDIR
     cd glfw-rs
     rm -rf build
     export PKG_CONFIG_PATH=$RUST_GAMEDEV_KIT_ROOT/install/lib/pkgconfig 
-    make lib LINK_ARGS=`pkg-config --libs glfw3`
+    LINK_ARGS=$(pkg-config --libs glfw3)
+    make lib LINK_ARGS="$LINK_ARGS"
     cp lib/* $LIBDIR
 )
 


### PR DESCRIPTION
Without this patch I got the following:

```
+ export PKG_CONFIG_PATH=/Users/schuller/Rust/rust-gamedev-kit/install/lib/pkgconfig
+ PKG_CONFIG_PATH=/Users/schuller/Rust/rust-gamedev-kit/install/lib/pkgconfig
++ pkg-config --libs glfw3
+ LINK_ARGS='-L/Users/schuller/Rust/rust-gamedev-kit/install/lib -lglfw '
+ make lib LINK_ARGS=-L/Users/schuller/Rust/rust-gamedev-kit/install/lib -lglfw
mkdir -p lib
rustc --out-dir=lib -C link-args="-L/Users/schuller/Rust/rust-gamedev-kit/install/lib" -O src/lib/lib.rs
error: linking with `cc` failed: exit code: 1
note: cc arguments: '-m64' '-L/Users/schuller/Rust/rust-gamedev-kit/install/lib/rustlib/x86_64-apple-darwin/lib' '-o' 'lib/libglfw-rs-c68009f4-0.1.dylib' 'lib/glfw-rs.o' 'lib/glfw-rs.metadata.o' '-nodefaultlibs' '-L/Users/schuller/Rust/rust-gamedev-kit/glfw-rs/.rust' '-L/Users/schuller/Rust/rust-gamedev-kit/glfw-rs' '-L/Users/schuller/Rust/rust-gamedev-kit/install/lib/rustlib/x86_64-apple-darwin/lib' '-lstd-966edb7e-0.10-pre' '-L/Users/schuller/Rust/rust-gamedev-kit/install/lib/rustlib/x86_64-apple-darwin/lib' '-lsemver-87b2230f-0.10-pre' '-L/Users/schuller/Rust/rust-gamedev-kit/install/lib/rustlib/x86_64-apple-darwin/lib' '-lsync-7bf3a0fc-0.10-pre' '-lSystem' '-dynamiclib' '-Wl,-dylib' '-Wl,-install_name,@rpath/libglfw-rs-c68009f4-0.1.dylib' '-Wl,-rpath,@loader_path/../../install/lib/rustlib/x86_64-apple-darwin/lib' '-Wl,-rpath,/Users/schuller/Rust/rust-gamedev-kit/install/lib/rustlib/x86_64-apple-darwin/lib' '-lmorestack' '-lcompiler-rt' '-L/Users/schuller/Rust/rust-gamedev-kit/install/lib'
note: ld: warning: directory not found for option '-L/Users/schuller/Rust/rust-gamedev-kit/glfw-rs/.rust'
Undefined symbols for architecture x86_64:
  "_glfwCreateWindow", referenced from:
      Window::create_intern::h6c62eb8fae066698Igf::v0.1 in glfw-rs.o
```
